### PR TITLE
Relax pytest version range

### DIFF
--- a/pytest_codestyle.py
+++ b/pytest_codestyle.py
@@ -12,11 +12,11 @@ def pytest_addoption(parser):
                     default=False, help='run pycodestyle')
 
     parser.addini('codestyle_max_line_length', default=pycodestyle.MAX_LINE_LENGTH,
-                  help=f"set maximum allowed line length (default: {default_max_line_length})")
+                  help='set maximum allowed line length (default: {})'.format(default_max_line_length))
     parser.addini('codestyle_select', type='args',
                   help='select errors and warnings (default: [])')
     parser.addini('codestyle_ignore', type='args',
-                  help=f"skip errors and warnings (default: [{' '.join(default_ignore)}])")
+                  help='skip errors and warnings (default: [{}])'.format(' '.join(default_ignore)))
     parser.addini('codestyle_show_source', type="bool", default=True,
                   help='show source code for each error (default: True)')
 
@@ -31,7 +31,7 @@ class Item(pytest.Item, pytest.File):
     CACHE_KEY = 'codestyle/mtimes'
 
     def __init__(self, path, parent):
-        super().__init__(path, parent)
+        super(Item, self).__init__(path, parent)
         self.add_marker('codestyle')
 
     def setup(self):
@@ -44,7 +44,7 @@ class Item(pytest.Item, pytest.File):
         # http://pycodestyle.pycqa.org/en/latest/api.html#pycodestyle.Checker
         # http://pycodestyle.pycqa.org/en/latest/advanced.html
         checker = pycodestyle.Checker(
-                        filename=self.fspath,
+                        filename=self.fspath.strpath,
                         max_line_length=int(self.config.getini('codestyle_max_line_length')),
                         select=self.config.getini('codestyle_select'),
                         ignore=self.config.getini('codestyle_ignore'),
@@ -64,7 +64,7 @@ class Item(pytest.Item, pytest.File):
         if excinfo.errisinstance(CodeStyleError):
             return excinfo.value.args[0]
         else:
-            return super().repr_failure(excinfo)
+            return super(Item, self).repr_failure(excinfo)
 
     def reportinfo(self):
         # https://github.com/pytest-dev/pytest/blob/4678cbeb913385f00cc21b79662459a8c9fafa87/_pytest/main.py#L550

--- a/pytest_codestyle.py
+++ b/pytest_codestyle.py
@@ -12,11 +12,11 @@ def pytest_addoption(parser):
                     default=False, help='run pycodestyle')
 
     parser.addini('codestyle_max_line_length', default=pycodestyle.MAX_LINE_LENGTH,
-                  help='set maximum allowed line length (default: {})'.format(default_max_line_length))
+                  help=f"set maximum allowed line length (default: {default_max_line_length})")
     parser.addini('codestyle_select', type='args',
                   help='select errors and warnings (default: [])')
     parser.addini('codestyle_ignore', type='args',
-                  help='skip errors and warnings (default: [{}])'.format(' '.join(default_ignore)))
+                  help=f"skip errors and warnings (default: [{' '.join(default_ignore)}])")
     parser.addini('codestyle_show_source', type="bool", default=True,
                   help='show source code for each error (default: True)')
 
@@ -31,7 +31,7 @@ class Item(pytest.Item, pytest.File):
     CACHE_KEY = 'codestyle/mtimes'
 
     def __init__(self, path, parent):
-        super(Item, self).__init__(path, parent)
+        super().__init__(path, parent)
         self.add_marker('codestyle')
 
     def setup(self):
@@ -44,7 +44,7 @@ class Item(pytest.Item, pytest.File):
         # http://pycodestyle.pycqa.org/en/latest/api.html#pycodestyle.Checker
         # http://pycodestyle.pycqa.org/en/latest/advanced.html
         checker = pycodestyle.Checker(
-                        filename=self.fspath.strpath,
+                        filename=self.fspath,
                         max_line_length=int(self.config.getini('codestyle_max_line_length')),
                         select=self.config.getini('codestyle_select'),
                         ignore=self.config.getini('codestyle_ignore'),
@@ -64,7 +64,7 @@ class Item(pytest.Item, pytest.File):
         if excinfo.errisinstance(CodeStyleError):
             return excinfo.value.args[0]
         else:
-            return super(Item, self).repr_failure(excinfo)
+            return super().repr_failure(excinfo)
 
     def reportinfo(self):
         # https://github.com/pytest-dev/pytest/blob/4678cbeb913385f00cc21b79662459a8c9fafa87/_pytest/main.py#L550

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='henry0312@gmail.com',
     license='MIT',
     py_modules=['pytest_codestyle'],
-    python_requires='>=3.6,<4',
+    python_requires='>=2.7,<3,>=3.6,<4',
     install_requires=[
         'pytest>=3.3,<3.4',
         'py>=1.5,<1.6',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['pytest_codestyle'],
     python_requires='>=2.7,<3,>=3.6,<4',
     install_requires=[
-        'pytest>=3.3,<3.4',
+        'pytest>=3.0,<3.4',
         'py>=1.5,<1.6',
         'pycodestyle>=2.3,<2.4',
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['pytest_codestyle'],
     python_requires='>=3.6,<4',
     install_requires=[
-        'pytest>=3.0,<3.4',
+        'pytest>=3.0,<4',
         'py>=1.5,<1.6',
         'pycodestyle>=2.3,<2.4',
     ],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author_email='henry0312@gmail.com',
     license='MIT',
     py_modules=['pytest_codestyle'],
-    python_requires='>=2.7,<3,>=3.6,<4',
+    python_requires='>=3.6,<4',
     install_requires=[
         'pytest>=3.0,<3.4',
         'py>=1.5,<1.6',


### PR DESCRIPTION
~~What do you think about supporting Python 2.7?  I'm personally stuck on Python 2.7 a while longer. There wasn't much Python 3-specific code in this repo.~~ **EDIT:** reverted.

~~Also,~~ I'm using pytest 3.0.x personally. Seems to work here. I didn't see this repo using any >3.3 specifics.