### PR TITLE
fix install error on not locale environment (docker, etc...)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 
 version = open('VERSION').read().strip()
-long_description = open('README.md').read()
+long_description = open('README.md', encoding='utf-8').read()
 
 setup(
     name='pytest-codestyle',


### PR DESCRIPTION
Hi,

I get following error from pip (via PyPI):
```
(docker_venv) admin@aa534d2fb0b8:~/link$ pip install --upgrade pytest-codestyle
Collecting pytest-codestyle
  Using cached https://files.pythonhosted.org/packages/ba/a7/f4914994805e3860a09456ed6105f9c99c292ef5183c022a2b48cb8004d8/pytest-codestyle-1.2.2.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-wqh2o31i/pytest-codestyle/setup.py", line 6, in <module>
        long_description = open('README.md').read()
      File "/usr/local/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 516: ordinal not in range(128)

    ----------------------------------------
```

my environment is Ubuntu on docker, Python is version 3.5.2.

```python
>>> import locale
>>> locale.getpreferredencoding()
'ANSI_X3.4-1968'
```

Probably because README.md contains utf8 characters.

Thanks