### PR TITLE
Added marker for codestyle

### DIFF
--- a/pytest_codestyle.py
+++ b/pytest_codestyle.py
@@ -77,3 +77,7 @@ class Item(pytest.Item, pytest.File):
 
 class CodeStyleError(Exception):
     """custom exception for error reporting."""
+
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'codestyle: Test against pycodestyle')

--- a/test_pytest_codestyle.py
+++ b/test_pytest_codestyle.py
@@ -89,6 +89,16 @@ def test_cache(testdir):
     result.assert_outcomes(skipped=1, failed=1)
 
 
+def test_strict(testdir):
+    p = testdir.makepyfile("""
+        def test_blah():
+            pass
+    """)
+    p = p.write(p.read() + "\n")
+    result = testdir.runpytest('--strict', '--codestyle')
+    result.assert_outcomes(passed=2)
+
+
 class TestItem(object):
 
     def test_cache_key(self):


### PR DESCRIPTION
Currently if `--strict` is used with `--codestyle` pytest will error stating that there is not a registered marker for `codestyle`.

This pull requests adds in the marker and includes a test for the changes.