### PR TITLE
Add `::CODESTYLE` after files in pytest verbose mode

### DIFF
--- a/pytest_codestyle.py
+++ b/pytest_codestyle.py
@@ -41,6 +41,7 @@ class Item(pytest.Item, pytest.File):
     def __init__(self, path, parent):
         super().__init__(path, parent)
         self.add_marker('codestyle')
+        self._nodeid += '::CODESTYLE'
 
     def setup(self):
         old_mtime = self.config.cache.get(self.CACHE_KEY, {}).get(str(self.fspath), -1)


### PR DESCRIPTION
If there are many linter plugins, it would be necessary to tell which one is `FAIL` or `SKIPPED`.

It is supported by many linter plugins. This PR implements that.

The effect of this project:

```sh
$ pytest --verbose
...
pytest_codestyle.py::CODESTYLE PASSED
pytest_codestyle.py::ISORT PASSED
...
```