### PR TITLE
Fix a crash when `-p no:cacheprovider`

### DIFF
--- a/pytest_codestyle.py
+++ b/pytest_codestyle.py
@@ -43,6 +43,9 @@ class Item(pytest.Item, pytest.File):
         self.add_marker('codestyle')
 
     def setup(self):
+        if not hasattr(self.config, 'cache'):
+            return
+
         old_mtime = self.config.cache.get(self.CACHE_KEY, {}).get(str(self.fspath), -1)
         mtime = self.fspath.mtime()
         if old_mtime == mtime:
@@ -61,7 +64,7 @@ class Item(pytest.Item, pytest.File):
         file_errors, out, err = py.io.StdCapture.call(checker.check_all)
         if file_errors > 0:
             raise CodeStyleError(out)
-        else:
+        elif hasattr(self.config, 'cache'):
             # update cache
             # http://pythonhosted.org/pytest-cache/api.html
             cache = self.config.cache.get(self.CACHE_KEY, {})

--- a/test_pytest_codestyle.py
+++ b/test_pytest_codestyle.py
@@ -90,6 +90,20 @@ def test_cache(testdir):
     result.assert_outcomes(skipped=1, failed=1)
 
 
+def test_no_cacheprovider(testdir):
+    testdir.tmpdir.ensure('a.py')
+    testdir.makepyfile("""
+        def hello():
+            print('hello')
+    """)
+    # first run
+    result = testdir.runpytest('--codestyle', '-p', 'no:cacheprovider')
+    result.assert_outcomes(passed=1, failed=1)
+    # second run
+    result = testdir.runpytest('--codestyle', '-p', 'no:cacheprovider')
+    result.assert_outcomes(passed=1, failed=1)
+
+
 def test_strict(testdir):
     p = testdir.makepyfile("""
         def test_blah():


### PR DESCRIPTION
In some cases, it is helpful or necessary to run `pytest` with `-p no:cacheprovider`, like CI or configurations of `pycodestyle` changed. It is a practical way to `rm .pytest_cache`, but `pytest -p no:cacheprovider` is a better way.

There will be a crash when running `pytest -p no:cacheprovider`, which is fixed by this PR.

```python
    def setup(self):
>       old_mtime = self.config.cache.get(self.CACHE_KEY, {}).get(str(self.fspath), -1)
E       AttributeError: 'Config' object has no attribute 'cache'

pytest_codestyle.py:46: AttributeError
```