### PR TITLE
Fix PytestDeprecationWarning since pytest v5.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     py_modules=['pytest_pycodestyle'],
     python_requires='~=3.5',
     install_requires=[
-        'pytest~=5.3',
+        'pytest~=5.4',
         'pycodestyle',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     py_modules=['pytest_pycodestyle'],
     python_requires='~=3.5',
     install_requires=[
-        'pytest',
+        'pytest~=5.3',
         'pycodestyle',
     ],
     extras_require={


### PR DESCRIPTION
```
/usr/local/lib/python3.7/site-packages/pytest_pycodestyle.py:23: PytestDeprecationWarning: direct construction of Item has been deprecated, please use Item.from_parent
  return Item(path, parent, options)
```